### PR TITLE
VC typo fix

### DIFF
--- a/_datasets/bmf.md
+++ b/_datasets/bmf.md
@@ -104,8 +104,8 @@ bmf <- read.csv( filename )
 | :---: | :---: | :---: |
 | 0.0 | June 21 2024 | Beta Version |
 | 1.0 | July 1st 2024 | Unified BMF |
-| 1.1 | March 4th 2024 | Fixed EIN2 for consistent formatting |
-| 1.1 | March 4th 2024 | State-level BMFs |
+| 1.1 | March 4th 2025 | Fixed EIN2 for consistent formatting |
+| 1.1 | March 4th 2025 | State-level BMFs |
 
 
 Users are encouraged to submit any questions and comments regarding this data set on our [contact page](https://nccs.urban.org/nccs/contact/).

--- a/_datasets/bmf.md
+++ b/_datasets/bmf.md
@@ -104,8 +104,8 @@ bmf <- read.csv( filename )
 | :---: | :---: | :---: |
 | 0.0 | June 21 2024 | Beta Version |
 | 1.0 | July 1st 2024 | Unified BMF |
-| 1.1 | Marc 4th 2024 | Fixed EIN2 for consistent formatting |
-| 1.1 | Marc 4th 2024 | State-level BMFs |
+| 1.1 | March 4th 2024 | Fixed EIN2 for consistent formatting |
+| 1.1 | March 4th 2024 | State-level BMFs |
 
 
 Users are encouraged to submit any questions and comments regarding this data set on our [contact page](https://nccs.urban.org/nccs/contact/).


### PR DESCRIPTION
Fixing date typo from @Thiyaghessan [commit](05c47562e2aea00818483f4312d80c5588fa79d5) to close #70. I'm assuming the correct date is March 4, 2025 (the date of the commit).