### PR TITLE
Fix bundler platform mismatch in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,11 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.1'
-          bundler-cache: true
+
+      - name: Add Linux platform and install dependencies
+        run: |
+          bundle lock --add-platform x86_64-linux
+          bundle install
 
       - name: Build Jekyll site
         run: bundle exec jekyll build


### PR DESCRIPTION
Add x86_64-linux platform to bundle lock before installing dependencies. The Gemfile.lock only had Windows platform (x64-mingw-ucrt), causing bundler exit code 16 on Ubuntu runners.