### PR TITLE
ci: add contracts-guard caller (ADR 0022)

### DIFF
--- a/.github/workflows/contracts-guard.yml
+++ b/.github/workflows/contracts-guard.yml
@@ -1,0 +1,26 @@
+name: contracts-guard
+
+# Thin caller of the reusable contract-change guard in nccs-contracts (ADR 0022).
+# The guard logic lives once there; this file passes only this repo's
+# paths_regex. nccs (the website) is a CONSUMER of the geography crosswalks and
+# data via the BMF/data catalogs, so the contract-relevant surface is the
+# catalog manifests that enumerate the contracted S3 artifacts the site links.
+# Tune the regex as that surface evolves.
+#
+# The guard verifies ACKNOWLEDGMENT, not correctness: a PR that touches the
+# matched paths must carry an `ADR NNNN` breadcrumb (commit message or PR body)
+# or the `contracts-ack` label, so the nccs-contracts reconcile isn't silently
+# skipped. See nccs-contracts/CONTRIBUTING.md.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  contracts-guard:
+    uses: UrbanInstitute/nccs-contracts/.github/workflows/contracts-guard.yml@main
+    with:
+      paths_regex: '^catalogs/(AWS-.*\.csv|build-catalog-functions\.R|aws/.*)$'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,3 +53,16 @@ GitHub Pages serves from `main` directly (no Action publishes the site). The `Bu
 
 - Per-collection `readme.md` files inside `_datasets/`, `_resources/`, `_stories/` document the accepted frontmatter fields (these `readme.md`s are gitignored from Jekyll output via `_config.yml` exclude).
 - Author/citation frontmatter follows the [Quarto citation](https://quarto.org/docs/authoring/create-citeable-articles.html) shape. Prefer `author.id` referencing an entry in `_data/people.yml` over inlining `name`/`bio`.
+
+## Contract-change guard (ADR 0022)
+
+This site is a **consumer** of the geography crosswalks and NCCS data via the
+BMF/data catalogs. A PR that changes the catalog manifests enumerating the
+contracted S3 artifacts the site links must acknowledge the
+[`nccs-contracts`](https://github.com/UrbanInstitute/nccs-contracts) impact, or
+CI fails. The `.github/workflows/contracts-guard.yml` caller (a thin wrapper
+over the reusable guard in `nccs-contracts`) fires on PRs that change
+`catalogs/AWS-*.csv`, `catalogs/build-catalog-functions.R`, or `catalogs/aws/*`.
+To pass: add an `ADR NNNN` breadcrumb to a commit message or the PR body, **or**
+add the `contracts-ack` label if there's genuinely no contract impact. The guard
+checks *acknowledgment, not correctness*.


### PR DESCRIPTION
Adds the thin caller of the reusable contract-change guard in `nccs-contracts` (ADR 0022, Migration step 3) + a `CLAUDE.md` pointer.

The `nccs` website is a **consumer** of the geography crosswalks and NCCS data via the BMF/data catalogs, so the guard fires on changes to the catalog manifests that enumerate the contracted S3 artifacts the site links.

**`paths_regex`:** `^catalogs/(AWS-.*\.csv|build-catalog-functions\.R|aws/.*)$` — fuzziest of the set (a Quarto site, not a code producer); narrow/widen as the catalog surface settles.

Verifies **acknowledgment, not correctness**: a matching PR must carry an `ADR NNNN` breadcrumb or the `contracts-ack` label. Always runs, passes when irrelevant — safe to mark required.

ADR 0022

🤖 Generated with [Claude Code](https://claude.com/claude-code)