### PR TITLE
fix(resources): point Legal Compendium link to public share URL

### DIFF
--- a/_resources/regulation-of-np-sector.md
+++ b/_resources/regulation-of-np-sector.md
@@ -13,7 +13,7 @@ primaryLinks:
   - text: Project Overview
     href: 'https://www.urban.org/sites/default/files/2023-10/Regulation of Nonprofits and Philanthropy description.pdf'
   - text: Digitized Legal Compendium
-    href: https://airtable.com/app2JZnG1dnoselbB/shr6UmCN2dosIrTtN
+    href: https://airtable.com/app2JZnG1dnoselbB/shrTlYpAk53YAzjyV
   - text: Project Page
     href: https://www.urban.org/policy-centers/center-nonprofits-and-philanthropy/projects/regulation-charitable-sector-project
 pubs:


### PR DESCRIPTION
## Summary
- Updates the header "Digitized Legal Compendium" action button on the Regulation of Nonprofits and Philanthropy project page to use the public Airtable **share** URL, matching the in-body button.
- Previously the header link pointed at a different Airtable view (`shr6UmCN2dosIrTtN`); it now uses the same public share link (`shrTlYpAk53YAzjyV`) so site visitors can open the interactive Legal Compendium.

## Notes
- Single-file content change (`_resources/regulation-of-np-sector.md`); no catalog manifests touched, so the contracts-guard (ADR 0022) does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)