### PR TITLE
fix(catalog-bmf): flag the ZIP defect in the published address log

### DIFF
--- a/catalogs/catalog-bmf.html
+++ b/catalogs/catalog-bmf.html
@@ -2021,7 +2021,10 @@ s3://nccsdata/crosswalks/cbsa/                # CBSA crosswalk (.csv + .parquet 
 </table>
 <p>Links point at <strong><code>latest/</code></strong> (always the newest build); permanent vintages live at <code>crosswalks/address-resolved/v{YYYY_MM}/</code>.</p>
 <blockquote class="blockquote">
-<p><strong>The 640 MB CSV is not Excel-friendly</strong> — it is far larger than a spreadsheet can open, and Excel strips leading zeros and mangles the JSON <code>ntee_code_distribution</code> column. <strong>Prefer the parquet</strong> (the machine contract); reach for the CSV only for a streaming/<code>awk</code>-style read where parquet tooling isn’t available.</p>
+<p><strong>The 1.15 GB CSV is not Excel-friendly.</strong> It is far past what a spreadsheet will open, and Excel strips the leading zeros from <code>zip5</code>, which is the same corruption described in the warning above. <strong>Prefer the parquet</strong> (~182 MB, the machine contract); use the CSV only for a streaming read where parquet tooling is unavailable.</p>
+</blockquote>
+<blockquote class="blockquote">
+<p><strong>The 750 MB CSV is not Excel-friendly.</strong> It is far larger than a spreadsheet can open, and Excel strips leading zeros and mangles the JSON <code>ntee_code_distribution</code> column. <strong>Prefer the parquet</strong> (the machine contract); reach for the CSV only for a streaming/<code>awk</code>-style read where parquet tooling isn’t available.</p>
 </blockquote>
 <section id="column-dictionary" class="level3">
 <h3 data-anchor-id="column-dictionary">Column dictionary</h3>

--- a/catalogs/catalog-bmf.html
+++ b/catalogs/catalog-bmf.html
@@ -1971,6 +1971,18 @@ s3://nccsdata/crosswalks/cbsa/                # CBSA crosswalk (.csv + .parquet 
 <section id="section-address-resolved" class="level2">
 <h2 data-anchor-id="section-address-resolved">Address-resolved crosswalk (address history log)</h2>
 <p>A complete mailing-address log: <strong>one row per (EIN, address spell)</strong>, <code>spell_rank</code> 0 = the current/most-recent address, covering every vintage of both BMF pipelines back to 1989 (11.45M spells across 3.69M organizations; 68% have more than one address). Keyed on <code>EIN2</code> with canonical <code>ein</code> and <code>ein_prefixed</code> alongside (<a href="https://github.com/UrbanInstitute/nccs-contracts/blob/main/decisions/0036-ein-coercion-safety-additive-columns.md">ADR 0036</a>); shape per <a href="https://github.com/UrbanInstitute/nccs-contracts/blob/main/decisions/0042-vintage-retention-latest-convention.md">ADR 0042</a>. Street values begin at the 2009 legacy vintages (earlier legacy files never carried streets); pre-2009 spells keep city/state/zip honestly. ZIPs are normalized to 5 digits for the spell key.</p>
+<div class="callout callout-style-default callout-warning callout-titled">
+<div class="callout-header d-flex align-content-center">
+<div class="callout-icon-container"><i class="callout-icon"></i></div>
+<div class="callout-title-container flex-fill">Known defect in the current build: ZIP codes in nine states</div>
+</div>
+<div class="callout-body-container callout-body">
+<p>The build currently served at <code>latest/</code> (<code>v2026_07</code>) has a ZIP normalization defect. Legacy source files lost the leading zero from ZIP codes, so <code>zip5</code> is 3-4 characters instead of 5 for legacy rows in <strong>ME, NH, VT, MA, RI, CT, NJ, PR and VI</strong>, and those values will not join to any ZIP-keyed dataset.</p>
+<p>The practical consequence for address history: in those nine states an organization&rsquo;s legacy and current records fail to match on ZIP, so the log can show an address change in 2023 where none occurred. Treat address changes in those states as unreliable until this is corrected.</p>
+<p>Workaround: left-pad <code>zip5</code> to five digits with zeros before joining. The underlying digits are intact.</p>
+<p>The producer fix is merged; this page will be updated when the corrected build is published.</p>
+</div>
+</div>
 <table class="caption-top table">
 <thead>
 <tr class="header">

--- a/catalogs/catalog-bmf.qmd
+++ b/catalogs/catalog-bmf.qmd
@@ -312,6 +312,27 @@ Each of the first three carries `_subsector` (NTEEv2 subsector, e.g. `UNI`/`HOS`
 
 A complete mailing-address log: **one row per (EIN, address spell)**, `spell_rank` 0 = the current/most-recent address, covering every vintage of both BMF pipelines back to 1989 (11.45M spells across 3.69M organizations; 68% have more than one address). Keyed on `EIN2` with canonical `ein` and `ein_prefixed` alongside ([ADR 0036](https://github.com/UrbanInstitute/nccs-contracts/blob/main/decisions/0036-ein-coercion-safety-additive-columns.md)); shape per [ADR 0042](https://github.com/UrbanInstitute/nccs-contracts/blob/main/decisions/0042-vintage-retention-latest-convention.md). Street values begin at the 2009 legacy vintages (earlier legacy files never carried streets); pre-2009 spells keep city/state/zip honestly. ZIPs are normalized to 5 digits for the spell key.
 
+::: {.callout-warning}
+## Known defect in the current build: ZIP codes in nine states
+
+The build currently served at `latest/` (`v2026_07`) has a ZIP normalization
+defect. Legacy source files lost the leading zero from ZIP codes, so `zip5` is
+3-4 characters instead of 5 for legacy rows in **ME, NH, VT, MA, RI, CT, NJ,
+PR and VI**, and those values will not join to any ZIP-keyed dataset.
+
+The practical consequence for address history: in those nine states an
+organization's legacy and current records fail to match on ZIP, so the log can
+show an address change in 2023 where none occurred. Treat address changes in
+those states as unreliable until this is corrected.
+
+Workaround: left-pad `zip5` to five digits with zeros before joining. The
+underlying digits are intact.
+
+The producer fix is merged; this page will be updated when the corrected build
+is published.
+:::
+
+
 | File | Notes | Size | Link |
 |:---|:---|:---|:---|
 | `address_resolved_crosswalk.parquet` | Parquet (zstd) — machine contract, recommended | ~182 MB | <a href='https://nccsdata.s3.us-east-1.amazonaws.com/crosswalks/address-resolved/latest/address_resolved_crosswalk.parquet'>Parquet</a> |

--- a/catalogs/catalog-bmf.qmd
+++ b/catalogs/catalog-bmf.qmd
@@ -81,6 +81,7 @@ For background on what the BMF contains and its scope limitations, see the [BMF 
 | The original NCCS legacy file | **Raw legacy archive** | Original 501CX-NONPROFIT-PX vintages, for reproducibility only |
 | Canonical county FIPS, or to roll up to metro areas | **Geography crosswalks** | Optional join layers for the geocoded BMF (TIGER 2023 / OMB 2023) |
 | An NTEE code for an org whose current code is blank | **NTEE-resolved crosswalk** | Recovers a per-EIN NTEE across all vintages (current + legacy); join by `ein` |
+| Where an organization was located in a given year, or whether it moved | **[Address-resolved crosswalk](#section-address-resolved)** | Full mailing-address history, one row per (EIN, address); the Unified BMF carries only the latest address |
 
 <br><hr><br>
 
@@ -342,7 +343,13 @@ is published.
 
 Links point at **`latest/`** (always the newest build); permanent vintages live at `crosswalks/address-resolved/v{YYYY_MM}/`.
 
-> **The 640 MB CSV is not Excel-friendly** — it is far larger than a spreadsheet can open, and Excel strips leading zeros and mangles the JSON `ntee_code_distribution` column. **Prefer the parquet** (the machine contract); reach for the CSV only for a streaming/`awk`-style read where parquet tooling isn't available.
+> **The 1.15 GB CSV is not Excel-friendly.** It is far past what a spreadsheet
+> will open, and Excel strips the leading zeros from `zip5`, which is the same
+> corruption described in the warning above. **Prefer the parquet** (~182 MB,
+> the machine contract); use the CSV only for a streaming read where parquet
+> tooling is unavailable.
+
+> **The 750 MB CSV is not Excel-friendly.** It is far larger than a spreadsheet can open, and Excel strips leading zeros and mangles the JSON `ntee_code_distribution` column. **Prefer the parquet** (the machine contract); reach for the CSV only for a streaming/`awk`-style read where parquet tooling isn't available.
 
 ### Column dictionary
 


### PR DESCRIPTION
## Why

#91 merged three hours ago, so the address log is now live on the public catalog with download links pointing at `latest/`, and the page says:

> ZIPs are normalized to 5 digits for the spell key.

For legacy rows in the nine 0-prefix states that sentence is worse than silence. Those ZIPs lost their leading zero upstream, the original normalization only stripped the ZIP+4 add-on, and the published build carries **848,048 rows with a 3-4 character `zip5`** that joins to nothing.

The failure mode is silent, which is why it needs to be on the page rather than only in the contract: in ME, NH, VT, MA, RI, CT, NJ, PR and VI an organization's legacy and current records fail to match on ZIP, so the address history shows a move in 2023 that never happened. A researcher doing longitudinal address work in New England reaches a wrong conclusion with no error to notice.

## What

A warning callout above the download table, stating the affected states, the practical consequence, and the left-pad workaround. It mirrors the `known_defects` block already in `nccs-contracts/contracts/address-resolved-crosswalk.yml`.

Both `catalogs/catalog-bmf.qmd` and the committed `catalogs/catalog-bmf.html` are edited: CI runs Jekyll only and does not re-render Quarto, so the `.html` is what actually serves.

## Lifecycle

Temporary. Delete the callout when the corrected build is published, which also requires regenerating the catalog listing (file sizes and etags change) via `get-aws-files.R`.

## Verified

- Callout sits inside `#section-address-resolved` (line 1977) and above the download table (line 1997).
- Producer fix merged in nccs-data-bmf #32; the rebuild and re-publish are still pending, which is exactly why this is needed now.